### PR TITLE
fix: add --branch=main to production deploy to prevent preview-only deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/ --project-name=voter-web
+          command: pages deploy dist/ --project-name=voter-web --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to Cloudflare Pages (Preview)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
GitHub Actions checkout leaves the repo in detached HEAD state, so
wrangler cannot detect the branch name from git. Without an explicit
--branch flag, Cloudflare Pages treats every deployment as a preview,
which is why the merge to main deployed to a hash-based preview URL
(3bd4206b.voter-web.pages.dev) instead of production (vote.kerryhatcher.com).

https://claude.ai/code/session_015Xff6P1J5Lr6k1KKnEeWVB