### PR TITLE
feat: full-screen map with bottom drawer on home and county pages

### DIFF
--- a/src/routes/counties/$countyId.tsx
+++ b/src/routes/counties/$countyId.tsx
@@ -204,7 +204,7 @@ function CountyDetailPage() {
 
       {/* Full-screen map */}
       {county.geometry ? (
-        <div className="h-full w-full">
+        <div className="relative z-0 h-full w-full">
           <CountyDetailMap
             countyGeometry={county.geometry}
             overlayData={overlayData}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,7 +31,7 @@ function Index() {
       </div>
 
       {/* Full-screen map */}
-      <div className="h-full w-full">
+      <div className="relative z-0 h-full w-full">
         {isLoading && (
           <div className="flex h-full items-center justify-center bg-muted/50">
             <div className="flex items-center gap-2 text-muted-foreground">


### PR DESCRIPTION
## Summary
- Full-screen map layout with floating toolbar and bottom drawer (Vaul) on both home page and county detail page
- Added shadcn drawer component, refactored root layout to full-height flex column with sticky nav
- Added GitHub Actions CI/CD with Cloudflare Pages preview deployments
- Fixed Leaflet z-index stacking issue where map panes (z-200–700) rendered above the Vaul drawer (z-50) by scoping Leaflet z-indexes within a stacking context (`relative z-0` on map wrapper)

## Test plan
- [ ] Open home page — map fills viewport, floating title visible, "State Demographics" drawer opens/closes correctly
- [ ] Click a county on the map — navigates to county detail page with floating toolbar and boundary type toggles
- [ ] Open "County Details" drawer on county page — slides up with county info, geographic details, and census demographics
- [ ] Verify drawer overlay dims background and clicking overlay closes drawer
- [ ] Verify login page layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)