### PR TITLE
feat: add welcome modal with help button to reopen

### DIFF
--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,0 +1,83 @@
+import { Link } from "@tanstack/react-router"
+import { Map, Database, Vote, Layers } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+const STORAGE_KEY = "welcome_dismissed"
+
+export function WelcomeModal({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const handleDismiss = () => {
+    localStorage.setItem(STORAGE_KEY, "true")
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDismiss}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Welcome to Voter Data Explorer</DialogTitle>
+          <DialogDescription>
+            An open-source tool for exploring voter registration data,
+            boundaries, and demographics across Georgia.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <h3 className="text-sm font-medium">Getting started</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex items-start gap-2">
+              <Map className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Click any county on the map to view its details, demographics,
+                and district boundaries.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <Layers className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Use the layer bar to toggle district overlays like
+                congressional, state house, and state senate boundaries.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <Database className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Each county page shows Census demographic data including
+                population, age, and housing statistics.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <Vote className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Sign in to access voter registration data and the address lookup
+                tool.
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row">
+          <Button variant="outline" asChild>
+            <Link to="/about" onClick={handleDismiss}>
+              Learn more
+            </Link>
+          </Button>
+          <Button onClick={handleDismiss}>Get started</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import { useEffect, useState } from "react"
-import { Loader2, LogIn, LogOut, Menu, Search, User } from "lucide-react"
+import { HelpCircle, Loader2, LogIn, LogOut, Menu, Search, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Sheet,
@@ -27,6 +27,7 @@ import { useStatewideOverlayTypes } from "@/hooks/useStatewideOverlayTypes"
 import { useUserRole } from "@/lib/hooks/use-user-role"
 import { AdminNavMenu, AdminNavLinks } from "@/components/admin-nav-menu"
 import { Toaster } from "@/components/ui/sonner"
+import { WelcomeModal } from "@/components/WelcomeModal"
 
 function MobileNav({
   headerTitle,
@@ -34,12 +35,14 @@ function MobileNav({
   user,
   onLogout,
   isAdmin,
+  onShowWelcome,
 }: {
   headerTitle: string | null
   isAuthenticated: boolean
   user: { username: string; role: string } | null
   onLogout: () => void
   isAdmin: boolean
+  onShowWelcome: () => void
 }) {
   const [open, setOpen] = useState(false)
 
@@ -77,6 +80,16 @@ function MobileNav({
               >
                 About
               </Link>
+            </SheetClose>
+            <SheetClose asChild>
+              <button
+                type="button"
+                className="py-2 text-sm text-left flex items-center gap-2"
+                onClick={onShowWelcome}
+              >
+                <HelpCircle className="h-4 w-4" />
+                Help
+              </button>
             </SheetClose>
             {isAuthenticated && (
               <SheetClose asChild>
@@ -274,6 +287,10 @@ function RootLayout() {
     }
   }
 
+  const [showWelcome, setShowWelcome] = useState(
+    () => localStorage.getItem("welcome_dismissed") !== "true",
+  )
+
   useEffect(() => {
     initialize()
   }, [initialize])
@@ -306,6 +323,14 @@ function RootLayout() {
             <Link to="/about" className="[&.active]:font-bold shrink-0">
               About
             </Link>
+            <button
+              type="button"
+              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setShowWelcome(true)}
+              aria-label="Help"
+            >
+              <HelpCircle className="h-4 w-4" />
+            </button>
             {isAuthenticated && (
               <Link
                 to="/lookup"
@@ -357,6 +382,7 @@ function RootLayout() {
           user={user}
           onLogout={handleLogout}
           isAdmin={isAdmin}
+          onShowWelcome={() => setShowWelcome(true)}
         />
 
         {/* Row 2: Layer controls (county detail or homepage) */}
@@ -393,6 +419,7 @@ function RootLayout() {
       <main className="flex-1 min-h-0 overflow-auto">
         <Outlet />
       </main>
+      <WelcomeModal open={showWelcome} onOpenChange={setShowWelcome} />
       <Toaster />
       <TanStackRouterDevtools />
     </div>


### PR DESCRIPTION
Show a welcome modal on first visit that introduces the app and explains
how to use it. Once dismissed, it persists via localStorage and can be
reopened from the help icon in both desktop and mobile navigation.

https://claude.ai/code/session_012HSZM2h8GBLdRB89ayP3Yd