### PR TITLE
fix(elections): keep county overlay below precincts after re-enable

### DIFF
--- a/src/components/elections/PrecinctMapView.tsx
+++ b/src/components/elections/PrecinctMapView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useEffect } from "react"
-import { MapContainer, TileLayer, GeoJSON, useMap } from "react-leaflet"
+import { MapContainer, TileLayer, GeoJSON, Pane, useMap } from "react-leaflet"
 import type { Layer, PathOptions } from "leaflet"
 import type { Feature, MultiPolygon, Polygon } from "geojson"
 import { AlertCircle, Loader2 } from "lucide-react"
@@ -40,6 +40,9 @@ const HOVER_STYLE: PathOptions = {
   fillOpacity: 0.7,
 }
 
+// Must stay below Leaflet's default overlayPane (z-index 400) so precincts remain interactive
+const COUNTY_OVERLAY_Z_INDEX = 350
+
 // Default center: Georgia
 const GA_CENTER: [number, number] = [32.6791, -83.6233]
 const GA_ZOOM = 7
@@ -64,17 +67,6 @@ function FitBoundsToPrecincts({
     )
   }, [map, geoJSON])
 
-  return null
-}
-
-function MapPanes() {
-  const map = useMap()
-  useEffect(() => {
-    if (!map.getPane("county-overlay")) {
-      const pane = map.createPane("county-overlay")
-      pane.style.zIndex = "350"
-    }
-  }, [map])
   return null
 }
 
@@ -137,7 +129,6 @@ function CountyOverlayLayer({
       onEachFeature={
         onEachFeature as (feature: Feature, layer: Layer) => void
       }
-      pane="county-overlay"
     />
   )
 }
@@ -325,16 +316,17 @@ export function PrecinctMapView({
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
-          <MapPanes />
           {hasRenderableFeatures && geoJSON ? (
             <>
               <FitBoundsToPrecincts geoJSON={geoJSON} />
               {showCountyOverlay && filteredCountyBoundaries && (
-                <CountyOverlayLayer
-                  counties={filteredCountyBoundaries}
-                  countyNames={countyNames}
-                  onCountyDblClick={handleCountyDblClick}
-                />
+                <Pane name="county-overlay" style={{ zIndex: COUNTY_OVERLAY_Z_INDEX }}>
+                  <CountyOverlayLayer
+                    counties={filteredCountyBoundaries}
+                    countyNames={countyNames}
+                    onCountyDblClick={handleCountyDblClick}
+                  />
+                </Pane>
               )}
               <PrecinctLayer geoJSON={geoJSON} dataUpdatedAt={dataUpdatedAt} candidateColorMap={candidateColorMap} />
               {/* District outline renders above precincts for visibility;


### PR DESCRIPTION
## Summary

- Fixes a bug where toggling the Counties checkbox off then on caused the county overlay to render on top of the precinct layer, blocking precinct hover/click interactions
- Root cause: React re-mounted the `CountyOverlayLayer` component, and Leaflet appends newly-added layers to the end of the overlay pane DOM, placing them on top
- Fix: Render county GeoJSON into a custom Leaflet pane (`county-overlay`) with z-index 350 (below the default overlay pane at 400), ensuring correct layer ordering regardless of mount sequence

## Test plan

- [ ] Navigate to an election results page with the precinct map
- [ ] Confirm counties render below precincts on initial load
- [ ] Uncheck "Counties", then re-check it
- [ ] Verify counties still render below precincts — hover and click on precincts should work normally
- [ ] Verify county double-click navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)