### PR TITLE
fix(elections): recognize "Election Night Complete" as reported precinct status

### DIFF
--- a/e2e/election-results.spec.ts
+++ b/e2e/election-results.spec.ts
@@ -16,6 +16,7 @@ import {
   ELECTION_ID,
   ELECTION_DATE,
   electionResultsWithNullCounts,
+  precinctGeoJSONElectionNightComplete,
 } from "./fixtures/mock-data"
 
 const RACE_URL = `/elections/${ELECTION_DATE}/${ELECTION_ID}`
@@ -150,6 +151,37 @@ test.describe("County dropdown z-index (clickability)", () => {
 
     // Trigger text should reflect the selected county
     await expect(trigger).toContainText("Bibb County")
+  })
+})
+
+// ==========================================================================
+// Bug Fix #4: "Election Night Complete" precincts not colored
+// ==========================================================================
+
+test.describe('Precinct "Election Night Complete" status (color fix)', () => {
+  test("precinct map renders when reporting_status is Election Night Complete", async ({
+    page,
+  }) => {
+    await setupElectionApiMocks(page, {
+      precinctGeoJSONOverride: precinctGeoJSONElectionNightComplete,
+    })
+
+    await page.goto(RACE_URL)
+
+    // Switch to precinct view
+    await page.getByLabel(/precinct/i).click()
+
+    // Give the map time to render
+    await page.waitForTimeout(1000)
+
+    // The "not available" overlay should NOT be visible — precincts should render
+    await expect(
+      page.getByText("Precinct boundaries are not available"),
+    ).not.toBeVisible()
+
+    // Leaflet map container should be present with rendered layers
+    const mapContainer = page.locator(".leaflet-container")
+    await expect(mapContainer).toBeVisible()
   })
 })
 

--- a/e2e/fixtures/election-api.ts
+++ b/e2e/fixtures/election-api.ts
@@ -25,6 +25,7 @@ import {
 
 export interface MockOptions {
   resultsOverride?: Record<string, unknown>
+  precinctGeoJSONOverride?: Record<string, unknown>
 }
 
 export async function setupElectionApiMocks(
@@ -32,6 +33,8 @@ export async function setupElectionApiMocks(
   options: MockOptions = {},
 ) {
   const results = options.resultsOverride ?? electionResultsResponse
+  const precinctGeoJSON =
+    options.precinctGeoJSONOverride ?? precinctGeoJSONResponse
 
   // Precinct GeoJSON (most specific — register first)
   await page.route(
@@ -40,7 +43,7 @@ export async function setupElectionApiMocks(
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(precinctGeoJSONResponse),
+        body: JSON.stringify(precinctGeoJSON),
       }),
   )
 

--- a/e2e/fixtures/mock-data.ts
+++ b/e2e/fixtures/mock-data.ts
@@ -190,6 +190,21 @@ export const precinctGeoJSONResponse = {
   ],
 }
 
+/**
+ * Variant with reporting_status "Election Night Complete" — regression test
+ * for the bug where precincts with this status were not colored by candidate.
+ */
+export const precinctGeoJSONElectionNightComplete = {
+  ...precinctGeoJSONResponse,
+  features: precinctGeoJSONResponse.features.map((f) => ({
+    ...f,
+    properties: {
+      ...f.properties,
+      reporting_status: "Election Night Complete",
+    },
+  })),
+}
+
 // ---------------------------------------------------------------------------
 // GET /boundaries/geojson?boundary_type=county_precinct&county=...
 // ---------------------------------------------------------------------------

--- a/src/components/elections/PrecinctMapView.tsx
+++ b/src/components/elections/PrecinctMapView.tsx
@@ -5,7 +5,7 @@ import type { Feature, MultiPolygon, Polygon } from "geojson"
 import { AlertCircle, Loader2 } from "lucide-react"
 import { cn, escapeHtml, stripCountySuffix } from "@/lib/utils"
 import { safeBbox, featuresWithGeometry } from "@/lib/geo"
-import { getPartyColor, getLeadingCandidate } from "@/types/elections"
+import { getPartyColor, getLeadingCandidate, isReported } from "@/types/elections"
 import type {
   PrecinctResultFeatureCollection,
   PrecinctResultGeoProperties,
@@ -29,10 +29,6 @@ interface PrecinctMapViewProps {
   onCountySelect: (county: string | undefined) => void
   showCountyOverlay: boolean
   showDistrictOutline: boolean
-}
-
-function isReported(status: string): boolean {
-  return status === "Reported" || status === "Fully Reported"
 }
 
 const HOVER_STYLE: PathOptions = {

--- a/src/types/elections.ts
+++ b/src/types/elections.ts
@@ -300,6 +300,18 @@ export function getLeadingCandidate(candidates: CandidateResult[]): CandidateRes
   return candidates.reduce((leader, c) => (c.vote_count > leader.vote_count ? c : leader))
 }
 
+/** Precinct reporting statuses that indicate results are available */
+const REPORTED_STATUSES = new Set([
+  "Reported",
+  "Fully Reported",
+  "Election Night Complete",
+])
+
+/** Check whether a precinct reporting status indicates results are available */
+export function isReported(status: string): boolean {
+  return REPORTED_STATUSES.has(status)
+}
+
 // ============================================================================
 // Feed Import Types
 // ============================================================================

--- a/tests/types/elections.test.ts
+++ b/tests/types/elections.test.ts
@@ -9,6 +9,7 @@ import {
   isActiveElection,
   getTotalVotes,
   getLeadingCandidate,
+  isReported,
   groupElectionsByDate,
   PARTY_COLORS,
   DEFAULT_PARTY_COLOR,
@@ -244,6 +245,32 @@ describe("getLeadingCandidate", () => {
   it("returns the candidate when only one exists", () => {
     const candidates = [mockCandidateResult({ id: "solo", vote_count: 50 })]
     expect(getLeadingCandidate(candidates)?.id).toBe("solo")
+  })
+})
+
+describe("isReported", () => {
+  it('returns true for "Reported"', () => {
+    expect(isReported("Reported")).toBe(true)
+  })
+
+  it('returns true for "Fully Reported"', () => {
+    expect(isReported("Fully Reported")).toBe(true)
+  })
+
+  it('returns true for "Election Night Complete"', () => {
+    expect(isReported("Election Night Complete")).toBe(true)
+  })
+
+  it('returns false for "Not Reported"', () => {
+    expect(isReported("Not Reported")).toBe(false)
+  })
+
+  it("returns false for empty string", () => {
+    expect(isReported("")).toBe(false)
+  })
+
+  it("returns false for unknown status", () => {
+    expect(isReported("Pending")).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- Extract `isReported()` from `PrecinctMapView.tsx` to shared `src/types/elections.ts` and add `"Election Night Complete"` to the recognized reporting statuses
- The API returns `reporting_status: "Election Night Complete"` for precincts, but the frontend only recognized `"Reported"` and `"Fully Reported"`, causing all precincts to render as gray (unreported)
- Add unit tests (6 cases) and an E2E regression test with a new mock variant

## Test plan

- [x] `npm run lint` — no lint errors
- [x] `npm test -- --run` — all 312 unit tests pass (6 new `isReported` tests)
- [x] `npm run build` — typecheck + build succeeds
- [x] `npm run test:e2e` — all 14 E2E tests pass (1 new regression test)
- [x] Visual verification via Playwright MCP — precinct polygons show candidate colors (blue for Dem lead) instead of gray

**Note:** The backend precinct GeoJSON endpoint only returns 5 of 46 precincts for this election. This fix correctly colors those 5, but the remaining 41 will still show as gray boundary-only features. That is a separate voter-api issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)